### PR TITLE
feat: accept onDestroy command to run before resource destruction

### DIFF
--- a/API.md
+++ b/API.md
@@ -501,6 +501,7 @@ Refer to the {@link https://registry.terraform.io/providers/hashicorp/null/3.2.2
 | <code><a href="#cdktf-local-exec.LocalExec.property.triggers">triggers</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 | <code><a href="#cdktf-local-exec.LocalExec.property.command">command</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdktf-local-exec.LocalExec.property.cwd">cwd</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdktf-local-exec.LocalExec.property.onDestroy">onDestroy</a></code> | <code>string</code> | *No description.* |
 
 ---
 
@@ -690,6 +691,16 @@ public readonly command: string;
 
 ```typescript
 public readonly cwd: string;
+```
+
+- *Type:* string
+
+---
+
+##### `onDestroy`<sup>Optional</sup> <a name="onDestroy" id="cdktf-local-exec.LocalExec.property.onDestroy"></a>
+
+```typescript
+public readonly onDestroy: string;
 ```
 
 - *Type:* string
@@ -1122,6 +1133,7 @@ const localExecConfig: LocalExecConfig = { ... }
 | <code><a href="#cdktf-local-exec.LocalExecConfig.property.copyBeforeRun">copyBeforeRun</a></code> | <code>boolean</code> | If set to true, the working directory will be copied to an asset directory. |
 | <code><a href="#cdktf-local-exec.LocalExecConfig.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
 | <code><a href="#cdktf-local-exec.LocalExecConfig.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#cdktf-local-exec.LocalExecConfig.property.onDestroy">onDestroy</a></code> | <code>string</code> | Command to run at destroy-time. |
 | <code><a href="#cdktf-local-exec.LocalExecConfig.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
 | <code><a href="#cdktf-local-exec.LocalExecConfig.property.triggers">triggers</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 
@@ -1184,6 +1196,18 @@ public readonly lifecycle: TerraformResourceLifecycle;
 ```
 
 - *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `onDestroy`<sup>Optional</sup> <a name="onDestroy" id="cdktf-local-exec.LocalExecConfig.property.onDestroy"></a>
+
+```typescript
+public readonly onDestroy: string;
+```
+
+- *Type:* string
+
+Command to run at destroy-time.
 
 ---
 

--- a/test/local-exec.test.ts
+++ b/test/local-exec.test.ts
@@ -165,7 +165,6 @@ describe("LocalExec", () => {
     expect(fs.existsSync(path.resolve(__dirname, "test.txt"))).toBe(false);
   });
 
-
   test("can specify a command to run at destroy-time", () => {
     // Create a file in the working directory
     const { destroy } = apply((stack) => {

--- a/test/local-exec.test.ts
+++ b/test/local-exec.test.ts
@@ -24,7 +24,13 @@ const apply = (addConstructs: (scope: Construct) => void) => {
     cwd: outdir,
   });
 
-  return outdir;
+  const destroy = () => {
+    execSync("terraform destroy -auto-approve", {
+      cwd: outdir,
+    });
+  };
+
+  return { outdir, destroy };
 };
 
 const workingDirectoryForAsset = (manifestPath: string, name: string) => {
@@ -61,7 +67,7 @@ describe("LocalExec", () => {
 
   test("runs command inside copy of working directory", () => {
     // Create a file in the stack directory
-    const outdir = apply((stack) => {
+    const { outdir } = apply((stack) => {
       new LocalExec(stack, "myresource", {
         command: `cp ${__filename} test.txt`,
         cwd: __dirname,
@@ -112,7 +118,7 @@ describe("LocalExec", () => {
 
   test("runs command can use token value inside a command", () => {
     const passwordLength = 4;
-    const outdir = apply((stack) => {
+    const { outdir } = apply((stack) => {
       new provider.RandomProvider(stack, "random");
 
       const waiter = new LocalExec(stack, "timer", {
@@ -144,7 +150,7 @@ describe("LocalExec", () => {
 
   test("command can be overwritten", () => {
     // Create a file in the stack directory
-    const outdir = apply((stack) => {
+    const { outdir } = apply((stack) => {
       const exec = new LocalExec(stack, "myresource", {
         command: "ls -la",
         cwd: __dirname,
@@ -157,5 +163,22 @@ describe("LocalExec", () => {
 
     expect(fs.existsSync(path.resolve(workingDir, "test.txt"))).toBe(true);
     expect(fs.existsSync(path.resolve(__dirname, "test.txt"))).toBe(false);
+  });
+
+  test("can specify a command to run at destroy-time", () => {
+    // Create a file in the working directory
+    const { destroy } = apply((stack) => {
+      new LocalExec(stack, "test", {
+        command: "cp origin.txt test.txt",
+        cwd: testdir,
+        onDestroy: "rm test.txt",
+      });
+    });
+
+    expect(fs.existsSync(path.resolve(testdir, "test.txt"))).toBe(true);
+
+    destroy();
+
+    expect(fs.existsSync(path.resolve(testdir, "test.txt"))).toBe(false);
   });
 });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

Accept an optional command via `onDestroy` parameter to enable running a command during destroy-time.
See also: https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax#destroy-time-provisioners

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
